### PR TITLE
ci: add docs generation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,5 +17,11 @@ repos:
     hooks:
       - id: terraform_fmt
       # - id: terraform_validate
-      # - id: terraform_docs
+      - id: terraform_docs
+        exclude: ^examples/.*
+        args:
+        - --args=--config=.terraform-docs.yml
+        - --hook-config=--path-to-file=README.md
+        - --hook-config=--add-to-existing-file=true
+        - --hook-config=--create-file-if-not-exist=true
       # - id: terraform_tflint

--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,63 @@
+formatter: markdown
+
+version: ""
+
+header-from: main.tf
+footer-from: ""
+
+recursive:
+  enabled: false
+  path: modules
+  include-main: true
+
+sections:
+  hide: []
+  show: []
+
+content: |-
+  {{ .Header }}
+
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
+  {{ .Providers }}
+
+  # Examples
+
+  ```hcl
+  {{ include "examples/primary/main.tf" }}
+  ```
+
+  {{ .Resources }}
+
+output:
+  file: ""
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+output-values:
+  enabled: false
+  from: ""
+
+sort:
+  enabled: true
+  by: name
+
+settings:
+  anchor: true
+  color: true
+  default: true
+  description: false
+  escape: true
+  hide-empty: false
+  html: true
+  indent: 2
+  lockfile: true
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,121 @@
 # terraform-aws-infraweave-central
 
-Alpha version, expect breaking changes
+Alpha version, expect changes to happen
+
+<!-- BEGIN_TF_DOCS -->
+
+<!-- END_TF_DOCS -->
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_all_regions"></a> [all\_regions](#input\_all\_regions) | List of all regions that forms the InfraWeave platform | `list(string)` | n/a | yes |
+| <a name="input_all_workload_projects"></a> [all\_workload\_projects](#input\_all\_workload\_projects) | List of workload project names to project id + regions, github\_repos should to be set when `enable_webhook_processor` is true | <pre>list(<br/>    object({<br/>      project_id          = string<br/>      name                = string<br/>      description         = string<br/>      regions             = list(string)<br/>      github_repos_deploy = list(string)<br/>      github_repos_oidc   = list(string)<br/>    })<br/>  )</pre> | n/a | yes |
+| <a name="input_create_github_oidc_provider"></a> [create\_github\_oidc\_provider](#input\_create\_github\_oidc\_provider) | n/a | `bool` | `true` | no |
+| <a name="input_enable_webhook_processor"></a> [enable\_webhook\_processor](#input\_enable\_webhook\_processor) | Create a webhook processor for the region, should be enabled in all regions if enabled in primary | `bool` | `false` | no |
+| <a name="input_enable_webhook_processor_endpoint"></a> [enable\_webhook\_processor\_endpoint](#input\_enable\_webhook\_processor\_endpoint) | Create a public webhook endpoint for the region for GitHub application or Gitlab Webhook integration. Only needed for primary, however, it can be enabled in secondary regions as well if you need redundancy. Messages will be routed to the correct region based on the project\_map anyway. | `bool` | `false` | no |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment for InfraWeave, e.g. dev, test, prod | `string` | n/a | yes |
+| <a name="input_oidc_allowed_github_repos"></a> [oidc\_allowed\_github\_repos](#input\_oidc\_allowed\_github\_repos) | List of allowed GitHub repositories in format ["SomeOrg/repo", "AnotherOrg/another-repo"] for access to the platform | `list(string)` | `[]` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS region | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_oidc_role_arn"></a> [oidc\_role\_arn](#output\_oidc\_role\_arn) | n/a |
+| <a name="output_webhook_endpoint"></a> [webhook\_endpoint](#output\_webhook\_endpoint) | n/a |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.77.0 |
+
+# Examples
+
+```hcl
+module "workload-project1-dev-us-west-2" {
+  source = "git::https://github.com/infraweave-io/terraform-aws-infraweave-workload.git?ref=<VERSION>"
+
+  region = "us-west-2"
+  providers = {
+    aws = aws.workload-project1-dev-us-west-2
+  }
+
+  environment        = local.environment
+  central_account_id = local.central_account_id
+
+  all_workload_projects = [ # Only to be set in the primary region of the workload account
+    {
+      project_id  = "111111111111"
+      name        = "Workload Account"
+      description = "Workload Account for testing"
+      regions     = ["us-west-2", "eu-central-1"]
+      github_repos_deploy = [
+        "your-org/my-infra",
+      ]
+      github_repos_oidc = [
+        "your-org/module-s3bucket",
+        "your-org/module-vpc",
+        # ...
+      ]
+    }
+  ]
+}
+```
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_dynamodb_resource_policy.change_records](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_resource_policy) | resource |
+| [aws_dynamodb_resource_policy.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_resource_policy) | resource |
+| [aws_dynamodb_resource_policy.deployments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_resource_policy) | resource |
+| [aws_dynamodb_resource_policy.events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_resource_policy) | resource |
+| [aws_dynamodb_resource_policy.modules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_resource_policy) | resource |
+| [aws_dynamodb_resource_policy.policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_resource_policy) | resource |
+| [aws_dynamodb_resource_policy.terraform_locks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_resource_policy) | resource |
+| [aws_dynamodb_table.change_records](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_dynamodb_table.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_dynamodb_table.deployments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_dynamodb_table.events](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_dynamodb_table.modules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_dynamodb_table.policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_dynamodb_table.terraform_locks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_dynamodb_table_item.all_projects](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table_item) | resource |
+| [aws_dynamodb_table_item.config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table_item) | resource |
+| [aws_kms_alias.central_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
+| [aws_kms_key.central](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_s3_bucket.change_records_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.modules_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.policies_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_policy.change_records_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.modules_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.policies_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_policy.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.change_records_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.modules_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.policies_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.change_records](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.modules](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.policies](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.change_records_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_versioning.modules_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_versioning.policies_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_versioning.terraform_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_versioning.versioning_example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_ssm_parameter.change_records_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.dynamodb_events_table_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.modules_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.modules_table_name](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.policies_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_organizations_organization.current_org](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/organizations_organization) | data source |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/primary/main.tf
+++ b/examples/primary/main.tf
@@ -1,0 +1,28 @@
+module "workload-project1-dev-us-west-2" {
+  source = "git::https://github.com/infraweave-io/terraform-aws-infraweave-workload.git?ref=<VERSION>"
+
+  region = "us-west-2"
+  providers = {
+    aws = aws.workload-project1-dev-us-west-2
+  }
+
+  environment        = local.environment
+  central_account_id = local.central_account_id
+
+  all_workload_projects = [ # Only to be set in the primary region of the workload account
+    {
+      project_id  = "111111111111"
+      name        = "Workload Account"
+      description = "Workload Account for testing"
+      regions     = ["us-west-2", "eu-central-1"]
+      github_repos_deploy = [
+        "your-org/my-infra",
+      ]
+      github_repos_oidc = [
+        "your-org/module-s3bucket",
+        "your-org/module-vpc",
+        # ...
+      ]
+    }
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
 
 variable "environment" {
   type        = string
-  description = "Environment, e.g. dev, test, prod"
+  description = "Environment for InfraWeave, e.g. dev, test, prod"
 }
 
 variable "region" {


### PR DESCRIPTION
This pull request introduces changes to enhance the automation and documentation of Terraform modules in the repository. Key updates include enabling the `terraform_docs` pre-commit hook with custom configurations, adding a `.terraform-docs.yml` configuration file, and improving the `README.md` by integrating auto-generated documentation. Additionally, new examples and minor variable description updates have been included.

### Pre-commit Hook Enhancements:
* Enabled the `terraform_docs` pre-commit hook with custom configurations to exclude `examples/` and specify arguments for generating and injecting documentation into the `README.md` file.

### Documentation Improvements:
* Introduced a `.terraform-docs.yml` configuration file to define formatting, content structure, and output settings for generating Terraform module documentation. 
* Updated `README.md` to include placeholders for auto-generated Terraform documentation, such as inputs, outputs, providers, and resources. 

### Examples:
* Added a new example in `examples/primary/main.tf` to demonstrate the usage of the Terraform module, including configuration for workload projects. 

### Minor Updates:
* Clarified the description of the `environment` variable to specify its purpose for InfraWeave environments. 